### PR TITLE
Support for `walletConfig`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.2.2",
+  "version": "0.2.3-beta.3",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.2.3-beta.3",
+  "version": "0.2.3-beta.4",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { default as Wallet } from './wallet'
 export { decrypt } from './encryption/decrypt'
 export { encrypt } from './encryption/encrypt'
 export * from './profiles'
+export * from './identity'
 
 export default {
   Wallet,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ import IdentityAddressOwnerNode from '../nodes/identity-address-owner-node'
 import { createSha2Hash } from 'blockstack/lib/encryption/sha2Hash'
 import { publicKeyToAddress } from 'blockstack/lib/keys'
 import Identity from '../identity'
+import { AssertionError } from 'assert'
 
 const IDENTITY_KEYCHAIN = 888
 const BLOCKSTACK_ON_BITCOIN = 0
@@ -155,4 +156,10 @@ export const makeIdentity = async (masterKeychain: BIP32Interface, index: number
     usernames: [],
   })
   return identity
+}
+
+export function assertIsTruthy<T>(val: any): asserts val is NonNullable<T> {
+  if (!val) {
+    throw new AssertionError({ expected: true, actual: val })
+  }
 }

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -2,7 +2,7 @@ import { generateMnemonic, mnemonicToSeed } from 'bip39'
 import { bip32, BIP32Interface } from 'bitcoinjs-lib'
 import { randomBytes } from 'blockstack/lib/encryption/cryptoRandom'
 
-import { getBlockchainIdentities, IdentityKeyPair, makeIdentity } from '../utils'
+import { getBlockchainIdentities, IdentityKeyPair, makeIdentity, assertIsTruthy } from '../utils'
 import { encrypt} from '../encryption/encrypt'
 import Identity from '../identity'
 import { decrypt } from '../encryption/decrypt'
@@ -159,10 +159,13 @@ export class Wallet {
     await uploadToGaiaHub('wallet-config.json', encrypted, gaiaConfig, 'application/json')
   }
 
-  async updateConfigWithAuth({ identityIndex, app, gaiaConfig }: { identityIndex: number; app: ConfigApp; gaiaConfig: GaiaHubConfig; }) {
-    if (!this.walletConfig) {
-      throw 'Tried to update wallet config without fetching it first'
-    }
+  async updateConfigWithAuth({ identityIndex, app, gaiaConfig }: 
+  { 
+    identityIndex: number
+    app: ConfigApp
+    gaiaConfig: GaiaHubConfig 
+  }) {
+    assertIsTruthy<WalletConfig>(this.walletConfig)
 
     this.identities.forEach((identity, index) => {
       if (!this.walletConfig?.identities[index]) {
@@ -181,9 +184,7 @@ export class Wallet {
   }
 
   async updateConfigForReuseWarning({ gaiaConfig }: { gaiaConfig: GaiaHubConfig; }) {
-    if (!this.walletConfig) {
-      throw 'Tried to update wallet config without fetching it first'
-    }
+    assertIsTruthy<WalletConfig>(this.walletConfig)
 
     this.walletConfig.hideWarningForReusingIdentity = true
 

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -122,7 +122,7 @@ export class Wallet {
   async fetchConfig(gaiaConfig: GaiaHubConfig): Promise<WalletConfig | null> {
     try {
       const response = await fetch(`${gaiaConfig.url_prefix}/${gaiaConfig.address}/wallet-config.json`)
-      const encrypted = await response.json()
+      const encrypted = await response.text()
       const configJSON = await decryptContent(encrypted, { privateKey: this.configPrivateKey }) as string
       const config: WalletConfig = JSON.parse(configJSON)
       this.walletConfig = config

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -28,6 +28,7 @@ interface ConfigIdentity {
 
 export interface WalletConfig {
   identities: ConfigIdentity[]
+  hideWarningForReusingIdentity?: boolean
 }
 
 export interface ConstructorOptions {
@@ -176,6 +177,16 @@ export class Wallet {
     identity.apps[app.origin] = app
     this.walletConfig.identities[identityIndex] = identity
     console.log('updating config')
+    await this.updateConfig(gaiaConfig)
+  }
+
+  async updateConfigForReuseWarning({ gaiaConfig }: { gaiaConfig: GaiaHubConfig; }) {
+    if (!this.walletConfig) {
+      throw 'Tried to update wallet config without fetching it first'
+    }
+
+    this.walletConfig.hideWarningForReusingIdentity = true
+
     await this.updateConfig(gaiaConfig)
   }
 }

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,5 +1,6 @@
 import Wallet from '../src/wallet'
 import { decrypt } from '../src/encryption/decrypt'
+import { ECPair } from 'bitcoinjs-lib'
 
 describe('Restoring a wallet', () => {
   test('restores an existing wallet and keychain', async () => {
@@ -53,5 +54,12 @@ describe('Restoring a wallet', () => {
     const restored = await Wallet.restore(password, backupPhrase)
 
     expect(restored.identityPublicKeychain).toEqual(generated.identityPublicKeychain)
+  })
+
+  test('generates a config private key', async () => {
+    const wallet = await Wallet.generate('password')
+    expect(wallet.configPrivateKey).not.toBeFalsy()
+    const node = ECPair.fromPrivateKey(Buffer.from(wallet.configPrivateKey, 'hex'))
+    expect(node.privateKey).not.toBeFalsy()
   })
 })


### PR DESCRIPTION
This PR adds `walletConfig` to the `Wallet` class.

It's a wallet-level config file, persisted on Gaia. Used privately by the authenticator to keep track of apps used.

This is already mostly complete:

TODO:

- [ ] encrypt `walletConfig` in Gaia
- [ ] refactor `walletConfig` based on Kyran's feedback - https://github.com/blockstack/blockstack-app/pull/69#issuecomment-581777866
- [ ] keep track of the "Don't show this again" checkbox on the app re-use warning