### PR TITLE
Feature/add identity validation fn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.2.5-beta.1",
+  "version": "0.2.5-beta.3",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",
@@ -20,7 +20,7 @@
     "test:watch": "jest --watch --coverage=false",
     "lint": "eslint --ext .ts ./src ./tests -f unix",
     "lint:fix": "eslint --fix --ext .ts ./src ./tests -f unix",
-    "depcheck": "depcheck --ignores='@types/*,eslint*,safe-buffer,codecov,@typescript-eslint/*'",
+    "depcheck": "depcheck --ignores='@types/*,eslint*,safe-buffer,codecov,@typescript-eslint/*,@blockstack/*'",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "yarn build"
   },

--- a/package.json
+++ b/package.json
@@ -1,19 +1,38 @@
 {
   "name": "@blockstack/keychain",
-  "version": "0.2.4",
+  "version": "0.2.5-beta.1",
   "description": "A package for managing Blockstack keychains",
   "main": "./dist/index.js",
   "umd:main": "./dist/keychain.umd.production.js",
   "module": "./dist/keychain.esm.js",
   "author": "Hank Stoever",
   "types": "./dist/index.d.ts",
+  "scripts": {
+    "clean": "shx rm -rf ./lib*/",
+    "dev": "cross-env NODE_ENV=development tsdx watch",
+    "build": "cross-env NODE_ENV=production tsdx build --format=cjs,esm,umd",
+    "build-all": "run-p build:*",
+    "build:cjs": "tsc --outDir ./lib -m commonjs -t es2017",
+    "build:esm": "tsc --outDir ./lib-esm -m es6 -t es2017",
+    "build:cjs:watch": "tsc --outDir ./lib -m commonjs -t es2017 --watch",
+    "build:esm:watch": "tsc --outDir ./lib-esm -m es6 -t es2017 --watch",
+    "test": "jest",
+    "test:watch": "jest --watch --coverage=false",
+    "lint": "eslint --ext .ts ./src ./tests -f unix",
+    "lint:fix": "eslint --fix --ext .ts ./src ./tests -f unix",
+    "depcheck": "depcheck --ignores='@types/*,eslint*,safe-buffer,codecov,@typescript-eslint/*'",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "yarn build"
+  },
   "unpkg": "./dist/keychain.cjs.production.min.js",
   "license": "MIT",
   "files": [
     "dist"
   ],
   "typings": "dist/index.d.ts",
+  "prettier": "@blockstack/prettier-config",
   "devDependencies": {
+    "@blockstack/prettier-config": "^0.0.5",
     "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@types/jest": "^24.0.18",
     "@types/node": "^10.14.17",
@@ -32,23 +51,6 @@
     "ts-jest": "^24.0.2",
     "tsdx": "^0.11.0",
     "typescript": "^3.7.3"
-  },
-  "scripts": {
-    "clean": "shx rm -rf ./lib*/",
-    "dev": "cross-env NODE_ENV=development tsdx watch",
-    "build": "cross-env NODE_ENV=production tsdx build --format=cjs,esm,umd",
-    "build-all": "run-p build:*",
-    "build:cjs": "tsc --outDir ./lib -m commonjs -t es2017",
-    "build:esm": "tsc --outDir ./lib-esm -m es6 -t es2017",
-    "build:cjs:watch": "tsc --outDir ./lib -m commonjs -t es2017 --watch",
-    "build:esm:watch": "tsc --outDir ./lib-esm -m es6 -t es2017 --watch",
-    "test": "jest",
-    "test:watch": "jest --watch --coverage=false",
-    "lint": "eslint --ext .ts ./src ./tests -f unix",
-    "lint:fix": "eslint --fix --ext .ts ./src ./tests -f unix",
-    "depcheck": "depcheck --ignores='@types/*,eslint*,safe-buffer,codecov,@typescript-eslint/*'",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "bip39": "^3.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Wallet from './wallet'
+export * from './utils'
 export { default as Wallet } from './wallet'
 export { decrypt } from './encryption/decrypt'
 export { encrypt } from './encryption/encrypt'

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,63 @@
+import { IdentityNameValidityError, validateIdentityName, checkIdentityNameAvailability } from '../src/utils';
+import { Subdomains } from '../src';
+
+describe(validateIdentityName.name, () => {
+  it('returns error state when string less than 8 characters', () => {
+    const result = validateIdentityName('john')
+    expect(result).toEqual(IdentityNameValidityError.MINIMUM_LENGTH)
+  })
+
+  it('returns error state when string has more than 38 characters', () => {
+    const result = validateIdentityName('pneumonoultramicroscopicsilicovolcanoconiosis')
+    expect(result).toEqual(IdentityNameValidityError.MAXIMUM_LENGTH)
+  })
+
+  it('returns error state when using uppercase chars', () => {
+    const result = validateIdentityName('COOLNAMEBRO')
+    expect(result).toEqual(IdentityNameValidityError.ILLEGAL_CHARACTER)
+  })
+
+  it('returns error state when using non-underscore symbols', () => {
+    const result = validateIdentityName('kyranj@mie')
+    expect(result).toEqual(IdentityNameValidityError.ILLEGAL_CHARACTER)
+  })
+
+  it('returns error state when using non-underscore symbols', () => {
+    const result = validateIdentityName('COOLNAMEBRO')
+    expect(result).toEqual(IdentityNameValidityError.ILLEGAL_CHARACTER)
+  })
+
+  it('returns error state when using sneaky homoglyphs', () => {
+    const legitIndentity = 'kyranjamie'
+    const homoglyph = 'kyrаnjamie'
+    // eslint-disable-next-line 
+    // @ts-ignore
+    expect(legitIndentity === homoglyph).toEqual(false)
+    const shouldPassResult = validateIdentityName(legitIndentity)
+    expect(shouldPassResult).toBeNull()
+
+    const shouldFailResult = validateIdentityName(homoglyph)
+    expect(shouldFailResult).toEqual(IdentityNameValidityError.ILLEGAL_CHARACTER)
+  })
+
+  it('allows a selection of legit names', () => {
+    const names = [
+      'kyranjamie',
+      'jasperjansz101',
+      'auln3auuuu',
+      'honeypot1337',
+      'marina_p',
+      '42214218',
+      'emotion_trouble_solution_juice',
+      '________'
+    ]
+    names.forEach(name => expect(validateIdentityName(name)).toBeNull())
+  })
+})
+
+describe(checkIdentityNameAvailability.name, () => {
+  it('fetches the status of a username', async () => {
+    fetchMock.once(JSON.stringify({ success: true }))
+    expect(checkIdentityNameAvailability('slkdjfskldjf', Subdomains.BLOCKSTACK)).toEqual({ success: true })
+  })
+})

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -81,6 +81,7 @@ test('returns config if present', async () => {
   const stubConfig: WalletConfig = {
     identities: [{
       username: 'hankstoever.id',
+      address: '',
       apps: {
         'http://localhost:3000': {
           origin: 'http://localhost:3000',

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@blockstack/prettier-config@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@blockstack/prettier-config/-/prettier-config-0.0.5.tgz#871bd2a38b5bc9aabb1cefeeba6199cc64098957"
+  integrity sha512-A+wfdVwD1Sxd/D3PPJI67Evo7q2fp15hCOFLB5jmzcS1MdN8BQdFm6j51Sti8xLN4qHmuYkicbFBUluGx2h63g==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"


### PR DESCRIPTION
`validateIdentityName` will either return an error string from the enum, or `null` to indicate the lack thereof errors. Intentionally excluded are error texts/phrases for the user, e.g. _A username must more than 8 characters_. These may both vary in different contexts, and would also render the function useless if we ever localise our apps.

One feature I considered, but didn't build, is returning an object or array of all the errors, which would be useful in cases where we wish to display a break down of all violations.